### PR TITLE
Update README.md to advise updating wizard created plugin version

### DIFF
--- a/tutorials/Getting_Started/README.md
+++ b/tutorials/Getting_Started/README.md
@@ -30,6 +30,17 @@ packaging JDK 14 or later must be used.
 
 ![Create new project 3](screen5.png)
 
+### Update the wizard plugin
+The compose plugin version used in the wizard above may be out of date. Update the version of the plugin to the latest available. 
+E.g. at time of writing that wsa kotlin 1.4.30 and compose plugin version 0.3.0-build152.
+Find and update this in the build.gradle.kts file.
+```
+plugins {
+    kotlin("jvm") version "1.4.30"
+    id("org.jetbrains.compose") version "0.3.0-build152"
+}
+```
+
 ### Create new Compose project without the wizard
 
 It is also possible to create Compose project manually.


### PR DESCRIPTION
Using the compose plugin version created from the IDE wizard resulted in extremely slow (non functional) behaviour of the app on Linux 64bit.
Updating the plugin version made the example apps functional.